### PR TITLE
Minor bug fix

### DIFF
--- a/add_mesh_lsystem/lsystem.py
+++ b/add_mesh_lsystem/lsystem.py
@@ -173,7 +173,7 @@ class Turtle(object):
         self.radius *= value
 
     def term_expand_g(self, value=1 + expand_shrink_factor_g):
-        self.term_expand(1 + 0.48)
+        self.term_expand(value)
 
     def term_shrink_g(self, value=1 - expand_shrink_factor_g):
         self.term_shrink(value)


### PR DESCRIPTION
In function term_expand_g the argument 'value' was unused, and a constant 1+0.48 is hardcoded where the argument was, probably, intended to be used. This commit fixes that.

Thanks for your code, ento!
